### PR TITLE
fix PSNR error for averaging all batches

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -419,18 +419,17 @@ class PSNR(object):
     def __repr__(self):
         return "PSNR"
 
-    def __call__(self, y_pred, y_true, dim=1, threshold=None):
+    def __call__(self, y_pred, y_true, MAX_VALUE=1.):
         """
         args:
             y_true : 4-d ndarray in [batch_size, channels, img_rows, img_cols]
             y_pred : 4-d ndarray in [batch_size, channels, img_rows, img_cols]
-            threshold : [0.0, 1.0]
+            MAX_VALUE : either 1. or 255., the largest allowed value of input tensor.
         return PSNR, larger the better
         """
-        if threshold:
-            y_pred = _binarize(y_pred, threshold)
-        mse = torch.mean((y_pred - y_true) ** 2)
-        return 10 * torch.log10(1 / mse)
+        mse = torch.mean((y_pred - y_true) ** 2 , [1,2,3]) # mse of each batch, thus return size [batch_size,]
+        psnr = 10 * torch.log10(MAX_VALUE / mse) # PSNR of each batch, thus return size [batch_size,]
+        return torch.mean(psnr).item() # averaging over all batches.
 
 
 class SSIM(object):


### PR DESCRIPTION
Hi, thanks for the great work here!
However, i have noticed some thing weird when using `PSNR()` class.

the original implementation computes MSE over all batches of image, and calculate the PSNR over it:
`10log_10(255/MSE_avg)`, where `MSE_avg = mean(MSE)` over [B, C, H, W]

to calculate the mean PSNR, it should be:
`mean(10log_10(255/MSE_i))` over each batch, where `MSE_i` is MSE over each [C,H,W]

notice that the 2 approaches are: compute mean inside and outside log function,
which is not equivalent in terms of math.